### PR TITLE
symmetries of triangle image fix

### DIFF
--- a/src/groups.xml
+++ b/src/groups.xml
@@ -248,9 +248,9 @@
 						\node [above] at (3,10) {\emph{rotation}};
 
 						\draw (4,9) -- (6,9) -- ++(120:2) -- cycle;
-						\node [left] at (4,9) {$B$};
+						\node [left] at (4,9) {$C$};
 						\node [right] at (6,9) {$A$};
-						\node at (5,11.1) {$C$};
+						\node at (5,11.1) {$B$};
 						\node [right] at (7,10) {$ \rho_2 = \begin{pmatrix}A & B & C \\ C & A & B\end{pmatrix}$};
 
 						\draw (0,12) -- (2,12) -- ++(120:2) -- cycle;
@@ -262,8 +262,8 @@
 						\node [above] at (3,13) {\emph{rotation}};
 
 						\draw (4,12) -- (6,12) -- ++(120:2) -- cycle;
-						\node [left] at (4,12) {$C$};
-						\node [right] at (6,12) {$B$};
+						\node [left] at (4,12) {$B$};
+						\node [right] at (6,12) {$C$};
 						\node at (5,14.1) {$A$};
 						\node [right] at (7,13) {$ \rho_1 = \begin{pmatrix}A & B & C \\ B & C & A\end{pmatrix}$};
 


### PR DESCRIPTION
The illustrations in the figure *symmetries of a triangle* (currently figure 3.6) for rotations don't appear to match the respective descriptions as given in the arrays on the right (rho-1 and rho-2). It appears to be a typo that can be fixed by simply changing the vertex labels in the illustration.