### PR TITLE
Algebraic coding theory matrix typo

### DIFF
--- a/src/algcodes.xml
+++ b/src/algcodes.xml
@@ -1882,7 +1882,7 @@
           <me permid="mlH">
             H {\mathbf x} =
             \begin{pmatrix}
-            0 \\ 1 \\ 1
+            0 \\ 1 \\ 0
             \end{pmatrix}
           </me>.
           Examining the decoding table,


### PR DESCRIPTION
In http://abstract.ups.edu/aata/section-efficient-decoding.html Example 8.44
I think that the result should be (0, 1, 0) instead of (0, 1, 1).
I'm not sure it have to be fixed in this xml file, but please take a look.