### PR TITLE
fix a typo

### DIFF
--- a/src/groups.xml
+++ b/src/groups.xml
@@ -311,7 +311,7 @@
         </md>.
         This is the same symmetry as <m>\mu_2</m>.
         Suppose we do these motions in the opposite order,
-        <m>\rho_1</m> then <m>\mu_1</m>.
+        <m>\mu_1</m> then <m>\rho_1</m>.
         It is easy to determine that this is the same as the symmetry <m>\mu_3</m>;
         hence, <m>\rho_1 \mu_1 \neq \mu_1 \rho_1</m>.
         A multiplication table for the symmetries of an equilateral triangle


### PR DESCRIPTION
the original order was permutation rho_1 and then the permutation mu_1 so when we do these "in the opposed order" it has to be mu_1 and then rho_1