### PR TITLE
update project manifest and runestone pub file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # .git ignore for AATA repository
 script/Makefile.paths
+logs/
+.cache/
+generated-assets/

--- a/project.ptx
+++ b/project.ptx
@@ -4,59 +4,12 @@
     project. To edit the content of your document, open `src/aata.xml`
     (default location).
 -->
-<project>
+<project ptx-version="2" source="src" publication=".">
   <targets>
-    <target name="web">
-      <format>html</format>
-      <source>src/aata.xml</source>
-      <publication>publication/publication.ptx</publication>
-      <output-dir>output/web</output-dir>
-    </target>
-    <target name="french">
-      <format>html</format>
-      <source>src/aata.xml</source>
-      <publication>publication/publication-french.ptx</publication>
-      <output-dir>output/web</output-dir>
-    </target>
-    <target name="runestone">
-      <format>html</format>
-      <source>src/aata.xml</source>
-      <publication>publisher/runestone.xml</publication>
-      <output-dir>published/AATA</output-dir>
-    </target>
-    <target name="print" pdf-method="xelatex">
-      <format>pdf</format>
-      <source>src/aata.xml</source>
-      <publication>publication/publication.ptx</publication>
-      <output-dir>output/print</output-dir>
-    </target>
-    <target name="print-latex">
-      <format>latex</format>
-      <source>src/aata.xml</source>
-      <publication>publication/publication.ptx</publication>
-      <output-dir>output/print-latex</output-dir>
-    </target>
-    <target name="subset">
-      <format>html</format>
-      <source>src/aata.xml</source>
-      <publication>publication/publication.ptx</publication>
-      <output-dir>output/subset</output-dir>
-      <stringparam key="debug.skip-knowls" value="yes"/>
-      <!-- edit this to change the section/chapter/etc. to include
-           in your subset build -->
-      <xmlid-root>ch_first</xmlid-root>
-    </target>
+    <target name="web" format="html" source="aata.xml" publication="publication/publication.ptx"/>
+    <target name="french" format="html" source="aata.xml" publication="publication/publication-french.ptx"/>
+    <target name="runestone" format="html" source="aata.xml" publication="publisher/runestone.xml"/>
+    <target name="print" format="pdf" pdf-method="xelatex" source="aata.xml" publication="publication/publication.ptx"/>
+    <target name="print-latex" format="latex" source="aata.xml" publication="publication/publication.ptx"/>
   </targets>
-  <executables>
-      <latex>latex</latex>
-      <pdflatex>pdflatex</pdflatex>
-      <xelatex>xelatex</xelatex>
-      <pdfsvg>pdf2svg</pdfsvg>
-      <asy>asy</asy>
-      <sage>sage</sage>
-      <pdfpng>convert</pdfpng>
-      <pdfeps>pdftops</pdfeps>
-      <node>node</node>
-      <liblouis>file2brl</liblouis>
-    </executables>
 </project>

--- a/publisher/runestone.xml
+++ b/publisher/runestone.xml
@@ -14,20 +14,22 @@
 <publication>
 
     <source>
-        <version include="sage-info sage-exercises"/>
-        <directories external="../external" generated="../images"/>
+        <!-- <version include="sage-info sage-exercises"/> -->
+        <version include="production"/>
+        <directories external="../assets" generated="../generated-assets"/>
     </source>
 
-    <common>
+    <!-- <common>
         <tableofcontents level="2"/>
         <exercise-divisional hint="no"/>
-    </common>
+    </common> -->
 
     <numbering>
-        <divisions level="2"/>
-        <blocks    level="1"/>
-        <equations level="1"/>
-        <footnotes level="0"/>
+        <!-- <divisions level="2"/> -->
+        <blocks    level="2"/>
+        <projects level="2"/>
+        <equations level="2"/>
+        <footnotes level="2"/>
     </numbering>
 
     <!-- HTML-Specific Options -->
@@ -35,7 +37,7 @@
         <!-- counteract arbitrary default, in part since -->
         <!-- examples are not authored with titles       -->
         <knowl example="no"/>
-        <css style="default" colors="maroon_grey"/>
+        <css theme="default-modern"/>
         <platform host="runestone"/>
         <search variant="default"/>
     </html>


### PR DESCRIPTION
Turns out that the issue with runestone not being able to build was an outdated publication file.  I tried to match the regular publication file as best I could. 

But also, you now have a version 2 project.ptx manifest.  And I added some lines to `.gitignore` so you don't have to worry about having cached assets or logs tracked by github.